### PR TITLE
feat: increase time for track and indentify calls to 10 minutes

### DIFF
--- a/components/card/index.tsx
+++ b/components/card/index.tsx
@@ -97,7 +97,7 @@ const Card: FunctionComponent<ICardProps> = ({
 
   useEffect(() => {
     if (isMetaphor) {
-      const interval = setInterval(() => links.map(metaphorDnsResolution), 20000);
+      const interval = setInterval(() => links.map(metaphorDnsResolution), 600000);
 
       return () => clearInterval(interval);
     }


### PR DESCRIPTION
Requested by John and Jared to cut down on our excessive data usage in Segment. Let me know if I misread the TS, or if this is not desireable