### PR TITLE
fix: invalid API_URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ Note: You might need an AWS Managament Account
 ### Cluster Management (Local mode)
 
 1. Add the following env variable in your `.env` file
-2. `API_URL=http://localhost:8081/api/v1` 
+2. `API_URL=http://localhost:8081` 


### PR DESCRIPTION
The current documented `API_URL=http://localhost:8081/api/v1` lead to 404 responses from the kubefirst-api (the base path`/api/v1` is repeated twice)

![Screenshot 2023-10-18 at 20 17 27](https://github.com/kubefirst/console/assets/2116354/b240eb4d-18b7-4139-bb2d-786c16778996)

The `API_URL=http://localhost:8081`is the correct value



