### PR TITLE
feat: kubefirst pro checkbox

### DIFF
--- a/containers/ClusterForms/shared/AdvancedOptions/AdvancedOptions.tsx
+++ b/containers/ClusterForms/shared/AdvancedOptions/AdvancedOptions.tsx
@@ -76,6 +76,20 @@ const AdvancedOptions: FunctionComponent<AdvancedOptionsProps> = ({
               }}
             />
           </CheckboxContainer>
+          <CheckboxContainer>
+            <Typography variant="labelLarge" color={EXCLUSIVE_PLUM}>
+              By default the kubefirst installation includes the kubefirst UI component. If you do
+              not wish to install the UI please check the below.
+            </Typography>
+            <Checkbox
+              control={control}
+              name="skipInstallPro"
+              label="Do not install the UI component"
+              rules={{
+                required: false,
+              }}
+            />
+          </CheckboxContainer>
           {isAwsInstallation && (
             <CheckboxContainer>
               <Typography

--- a/redux/thunks/api.thunk.ts
+++ b/redux/thunks/api.thunk.ts
@@ -77,7 +77,7 @@ export const createCluster = createAsyncThunk<
       ...values?.akamai_auth,
     },
     log_file: `log_${new Date().getTime()}.log`,
-    install_kubefirst_pro: true,
+    install_kubefirst_pro: !values?.skipInstallPro,
   };
 
   await axios.post<{ message: string }>('/api/proxy', {

--- a/types/redux/index.ts
+++ b/types/redux/index.ts
@@ -16,6 +16,7 @@ export interface AdvancedOptions extends GitValues {
   subDomain?: string;
   imageRepository?: ImageRepository;
   cloudZone?: string;
+  skipInstallPro?: boolean;
 }
 
 export interface AuthValues {


### PR DESCRIPTION
## Description

This PR adds a checkbox to do not install the kubefirst pro in the mgmt cluster

## Related Issue(s)

Fixes https://github.com/kubefirst/kubefirst/issues/2202

## How to test
Spin up a new cluster zero, go to advanced options in the cluster details step and see the checkbox

![Screenshot 2024-07-23 at 10 08 39 AM](https://github.com/user-attachments/assets/08a1ebcf-8fc6-422d-b04b-1e55cc1ba9d8)

