### PR TITLE
feat: adding github release, notes, tag to repo ci release

### DIFF
--- a/.argo/release.yaml
+++ b/.argo/release.yaml
@@ -65,6 +65,22 @@ spec:
                   value: '{{workflow.parameters.appName}}'
                 - name: chartDir
                   value: 'charts/{{workflow.parameters.appName}}'
+        - - name: release-and-tag-main-with-notes
+            templateRef:
+              name: cwft-git
+              template: release-and-tag-main-with-notes
+              clusterScope: true
+            arguments:
+              artifacts:
+                - name: repo-source
+                  from: '{{steps.set-chart-versions.outputs.artifacts.repo-source}}'
+              parameters:
+                - name: orgName
+                  value: 'kubefirst'
+                - name: appName
+                  value: '{{workflow.parameters.appName}}'
+                - name: tagName
+                  value: '{{steps.get-initial-chart-version.outputs.result}}'
         - - name: set-environment-version
             templateRef:
               name: cwft-helm


### PR DESCRIPTION
## Description
release ci now generates notes, tag, and github release

## How to test
dispatch against main from the github action called "release"